### PR TITLE
Fix Pick of the Day parsing edge cases

### DIFF
--- a/tests/test_parsing.py
+++ b/tests/test_parsing.py
@@ -1,6 +1,10 @@
+import sys
 import unittest
+from pathlib import Path
 
-from pick_collector import extract_pick_fields, parse_pick_text
+sys.path.append(str(Path(__file__).resolve().parents[1] / "src"))
+
+from pick_collector import extract_pick_fields, parse_pick_text, parse_record  # type: ignore
 
 
 class ExtractPickFieldsTest(unittest.TestCase):
@@ -17,6 +21,23 @@ class ExtractPickFieldsTest(unittest.TestCase):
         self.assertEqual(fields["pick"], "Brewers ML (-130)")
         self.assertEqual(fields["recommended_wager"], "1.5u")
 
+    def test_potd_line_is_captured(self) -> None:
+        body = """POTD Record 25-8 (4 pushes)\n\nTodays POTD: Crystal Palace vs Liverpool - Liverpool to win. Odds 1.90 UK time: 15:00"""
+        fields = extract_pick_fields(body.splitlines())
+        self.assertEqual(fields["game"], "Crystal Palace vs Liverpool")
+        self.assertEqual(fields["pick"], "Liverpool to win. Odds 1.90 UK time: 15:00")
+
+    def test_parlay_pick_retains_full_detail(self) -> None:
+        body = """POTD: Real Madrid or draw vs Atletico + PSG ML vs Auxerre @1.65 5U"""
+        fields = extract_pick_fields(body.splitlines())
+        self.assertEqual(fields["pick"], "Real Madrid or draw vs Atletico + PSG ML vs Auxerre @1.65")
+        self.assertEqual(fields["recommended_wager"], "5U")
+
+    def test_wager_amount_line_is_cleaned(self) -> None:
+        body = """Season Record: 10-3\nToday's Pick: Team A vs Team B - Team A ML\nWager Amount: 1.5 units"""
+        fields = extract_pick_fields(body.splitlines())
+        self.assertEqual(fields["recommended_wager"], "1.5 units")
+
 
 class ParsePickTextTest(unittest.TestCase):
     def test_prefix_units_are_cleaned(self) -> None:
@@ -24,6 +45,17 @@ class ParsePickTextTest(unittest.TestCase):
         self.assertEqual(game, "Rangers")
         self.assertEqual(detail, "-1.5 (-120)")
         self.assertEqual(stake, "1U")
+
+
+class ParseRecordTest(unittest.TestCase):
+    def test_record_with_parenthetical_pushes(self) -> None:
+        record = parse_record("POTD Record 25-8 (4 pushes)")
+        self.assertIsNotNone(record)
+        assert record
+        self.assertEqual(record.wins, 25)
+        self.assertEqual(record.losses, 8)
+        self.assertEqual(record.pushes, 4)
+        self.assertEqual(record.display, "25-8 (4 pushes)")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- capture parenthetical push counts when parsing user records
- ignore record headings while extracting pick details and improve pick detection for POTD lines
- retain full parlay descriptions, clean wager amounts, and add regression tests for the new scenarios

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d81080aa1c832294963da12baa6658